### PR TITLE
the prefix of S3 folder is now user_id

### DIFF
--- a/app/controllers/fuzzfinders.rb
+++ b/app/controllers/fuzzfinders.rb
@@ -14,7 +14,8 @@ end
 
 # setup method for image file upload to Amazon S3 bucket
 def setup_s3
-  @s3_direct_post = S3_BUCKET.presigned_post(key: "uploads/#{SecureRandom.uuid}/${filename}", success_action_status: 201, acl: :public_read)
+  user_id = session[:user] ? session[:user]["id"].to_s + "-" : "none-"
+  @s3_direct_post = S3_BUCKET.presigned_post(key: "uploads/#{ user_id + SecureRandom.uuid}/${filename}", success_action_status: 201, acl: :public_read)
   @s3_hash = Hash.new
   @s3_hash['url'] = @s3_direct_post.url
   @s3_hash['urlstring'] = @s3_direct_post.url.to_s


### PR DESCRIPTION
I finally make the upload image trackable in a hacky way, since attaching meta data is S3 direct upload didn't work. please ignore my email, that didn't work.

This branch will make the prefix of folder name in S3 buck lead by the user_id. like this:
uploads/2-552d5fe0-dd7c-4b7d-81ac-5d24f32e65b5/filename.jpg
2 is the user_id, in this way you will know which image from which user.
